### PR TITLE
perf: optimize filter-already-released-advisory-rpms for speed

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -38,7 +38,7 @@ jobs:
             taskName=$(basename "${dir}")
             taskFile="${dir}/${taskName}.yaml"
             if [ -f "${taskFile}" ] \
-              && grep -q "name: use-trusted-artifact\|name: create-trusted-artifact" "${taskFile}"
+              && grep -q "name: use-trusted-artifact\|name: create-trusted-artifact\|oras push" "${taskFile}"
             then
               echo "Found a trusted artifacts compatible task: ${taskFile}"
               trustedArtifactsBasedTasks+=($dir)

--- a/scripts/run-local-tests.sh
+++ b/scripts/run-local-tests.sh
@@ -277,8 +277,8 @@ classify_tasks() {
             continue
         fi
         
-        # Check if task supports Trusted Artifacts (uses TA step actions)
-        if grep -q "name: use-trusted-artifact\|name: create-trusted-artifact" "$task_file"; then
+        # Check if task needs OCI registry (uses TA step actions or oras push)
+        if grep -q "name: use-trusted-artifact\|name: create-trusted-artifact\|oras push" "$task_file"; then
             trusted_artifacts_tasks+=("$item")
         else
             pvc_tasks+=("$item")

--- a/tasks/internal/filter-already-released-advisory-rpms-task/filter-already-released-advisory-rpms-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/filter-already-released-advisory-rpms-task.yaml
@@ -202,27 +202,31 @@ spec:
           exit 0
         fi
 
-        # === Phase 4: Extract all purls from all advisories and track which advisory each came from ===
-        echo "Extracting purls from advisories and building purl-to-advisory mapping..."
-        PURL_TO_ADVISORY_MAP_FILE=/tmp/purl_to_advisory_map.json
-        echo "{}" > "$PURL_TO_ADVISORY_MAP_FILE"
+        # === Phase 4: Extract all purls from all advisories ===
+        echo "Extracting purls from advisories..."
+        PURL_MAPS_FILE=/tmp/purl_advisory_maps.jsonl
+        : > "$PURL_MAPS_FILE"
 
         for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
           ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
           if [[ -f "$ADVISORY_FILE" ]]; then
-            ADVISORY_PURLS=$(yq -o=json \
+            yq -o=json \
               '.spec.content.artifacts // [] | [.[].purl] | map(select(. != null))' \
-              "$ADVISORY_FILE")
-
-            # Build map for all purls from this advisory at once (much faster than one-by-one)
-            ADVISORY_MAP=$(jq -n --arg advisory "$ADVISORY_FILE" --argjson purls "$ADVISORY_PURLS" \
-              '$purls | reduce .[] as $purl ({}; .[$purl] = $advisory)')
-
-            # Merge this advisory's map into the main map
-            UPDATED=$(jq -s '.[0] * .[1]' "$PURL_TO_ADVISORY_MAP_FILE" - <<< "$ADVISORY_MAP")
-            echo "$UPDATED" > "$PURL_TO_ADVISORY_MAP_FILE"
+              "$ADVISORY_FILE" \
+              | jq -c --arg adv "$ADVISORY_FILE" \
+                'reduce .[] as $p ({}; .[$p] = $adv)' \
+              >> "$PURL_MAPS_FILE"
           fi
         done
+
+        PURL_TO_ADVISORY_MAP_FILE=/tmp/purl_to_advisory_map.json
+        if [[ -s "$PURL_MAPS_FILE" ]]; then
+          jq -s 'reduce .[] as $m ({}; . * $m)' \
+            "$PURL_MAPS_FILE" > "$PURL_TO_ADVISORY_MAP_FILE"
+        else
+          echo "{}" > "$PURL_TO_ADVISORY_MAP_FILE"
+        fi
+        rm -f "$PURL_MAPS_FILE"
 
         echo "Total unique purls from advisories: $(jq 'keys | length' "$PURL_TO_ADVISORY_MAP_FILE")"
 
@@ -234,42 +238,29 @@ spec:
 
         UNRELEASED_FILE=/tmp/unreleased.json
         IN_ADVISORY_FILE=/tmp/in_advisory.json
-        echo "[]" > "$UNRELEASED_FILE"
-        echo "[]" > "$IN_ADVISORY_FILE"
-
-        # Track which advisories contain the in-advisory RPMs (for validation)
         ADVISORY_SET_FILE=/tmp/advisory_set.json
-        echo "[]" > "$ADVISORY_SET_FILE"
 
-        while IFS= read -r entry; do
-          entry_file=/tmp/current_entry.json
-          echo "$entry" > "$entry_file"
+        jq --slurpfile map "$PURL_TO_ADVISORY_MAP_FILE" '
+          . as $entries | $map[0] as $m |
+          reduce $entries[] as $e (
+            {unreleased: [], in_advisory: [], advisories: {}};
+            if $m[$e.purl] then
+              .in_advisory += [$e]
+              | .advisories[$m[$e.purl]] = true
+            else
+              .unreleased += [$e]
+            end
+          ) | {
+            unreleased,
+            in_advisory,
+            advisories: (.advisories | keys)
+          }
+        ' "$SNAPSHOT_FILE" > /tmp/categorized.json
 
-          purl=$(jq -r '.purl' "$entry_file")
-
-          # Check if purl exists in the map
-          advisory_path=$(jq -r --arg purl "$purl" '.[$purl] // ""' "$PURL_TO_ADVISORY_MAP_FILE")
-
-          if [[ -n "$advisory_path" ]]; then
-            # RPM found in advisory - add to in_advisory list for digest validation
-            UPDATED=$(jq --slurpfile e "$entry_file" '. + $e' "$IN_ADVISORY_FILE")
-            echo "$UPDATED" > "$IN_ADVISORY_FILE"
-
-            # Track which advisory this came from
-            advisory_already_tracked=$(jq --arg adv "$advisory_path" \
-              'map(select(. == $adv)) | length > 0' "$ADVISORY_SET_FILE")
-            if [[ "$advisory_already_tracked" == "false" ]]; then
-              UPDATED=$(jq --arg adv "$advisory_path" '. + [$adv]' "$ADVISORY_SET_FILE")
-              echo "$UPDATED" > "$ADVISORY_SET_FILE"
-            fi
-          else
-            # RPM not in any advisory - unreleased
-            UPDATED=$(jq --slurpfile e "$entry_file" '. + $e' "$UNRELEASED_FILE")
-            echo "$UPDATED" > "$UNRELEASED_FILE"
-          fi
-
-          rm -f "$entry_file"
-        done < <(jq -c '.[]' "$SNAPSHOT_FILE")
+        jq '.unreleased' /tmp/categorized.json > "$UNRELEASED_FILE"
+        jq '.in_advisory' /tmp/categorized.json > "$IN_ADVISORY_FILE"
+        jq '.advisories' /tmp/categorized.json > "$ADVISORY_SET_FILE"
+        rm -f /tmp/categorized.json
 
         # === Phase 6: Output results ===
         UNRELEASED_COUNT=$(jq 'length' "$UNRELEASED_FILE")

--- a/tasks/internal/filter-already-released-advisory-rpms-task/tests/mocks.sh
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/tests/mocks.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -eux
 
+function oras() {
+  local args=()
+  local insecure_added=false
+  for arg in "$@"; do
+    args+=("$arg")
+    if [[ "$insecure_added" == "false" && "$arg" =~ ^(push|pull|fetch|resolve|tag)$ ]]; then
+      args+=("--insecure")
+      insecure_added=true
+    fi
+  done
+  command oras "${args[@]}"
+}
+
 function git() {
   echo "Mock git called with: $*"
 
@@ -9,7 +22,6 @@ function git() {
   elif [[ "$1" == "sparse-checkout" ]]; then
     :
   elif [[ "$1" == "checkout" ]]; then
-    # Create advisory directory structure with advisory.yaml files
     mkdir -p data/advisories/test-origin/2025/1601
     mkdir -p data/advisories/test-origin/2025/1602
     touch data/advisories/test-origin/2025/1601/advisory.yaml
@@ -39,34 +51,36 @@ function find() {
 function yq() {
   echo "Mock yq called with: $*" >&2
 
-  if [[ -z "$3" ]]; then
-    echo "Error: Empty file path in yq command" >&2
-    exit 1
-  fi
+  if [[ "$1" == "-o=json" ]]; then
+    local advisory_path="$3"
+    local advisory_num
+    advisory_num=$(echo "$advisory_path" | awk -F'/' '{print $(NF-1)}')
 
-  advisory_path="$3"
-  advisory_num=$(echo "$advisory_path" | awk -F'/' '{print $(NF-1)}')
-
-  if [[ "$2" == ".spec.type" ]]; then
-    echo "RHBA"
-  elif [[ "$2" == ".metadata.name" ]]; then
-    advisory_year=$(echo "$advisory_path" | awk -F'/' '{print $(NF-2)}')
-    echo "${advisory_year}:${advisory_num}"
-  elif [[ "$2" == *".spec.content.artifacts"* ]]; then
     case "$advisory_num" in
       1601)
-        # These purls match RPMs that should be "in advisory"
         echo '["pkg:rpm/redhat/released-rpm@1.0-1.fc44?arch=x86_64", "pkg:rpm/redhat/all-released-a@1.0-1.fc44?arch=x86_64", "pkg:rpm/redhat/all-released-b@2.0-1.fc44?arch=x86_64"]'
-        ;;
-      1602)
-        echo '[]'
         ;;
       *)
         echo '[]'
         ;;
     esac
+  elif [[ "$1" == "-r" ]]; then
+    local advisory_path="$3"
+    local advisory_num
+    advisory_num=$(echo "$advisory_path" | awk -F'/' '{print $(NF-1)}')
+
+    if [[ "$2" == ".spec.type" ]]; then
+      echo "RHBA"
+    elif [[ "$2" == ".metadata.name" ]]; then
+      local advisory_year
+      advisory_year=$(echo "$advisory_path" | awk -F'/' '{print $(NF-2)}')
+      echo "${advisory_year}:${advisory_num}"
+    else
+      echo "Error: Unexpected yq -r query: $2" >&2
+      exit 1
+    fi
   else
-    echo "Error: Unexpected yq query: $2" >&2
+    echo "Error: Unexpected yq command: $*" >&2
     exit 1
   fi
 }

--- a/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-all-released.yaml
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-all-released.yaml
@@ -7,6 +7,21 @@ spec:
   description: |
     Test the filter-already-released-advisory-rpms-task when all RPMs are in advisories.
     Should return empty unreleased list and populated in_advisory list.
+  params:
+    - name: ociStorage
+      description: The OCI repository where artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      type: string
+      default: "1d"
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
   tasks:
     - name: run-filter-task
       taskRef:
@@ -22,25 +37,23 @@ spec:
           value: "filter-advisory-rpms-secret"
         - name: internalRequestPipelineRunName
           value: "$(context.pipelineRun.name)"
+        - name: ociStorage
+          value: $(params.ociStorage)
     - name: validate-result
       runAfter:
         - run-filter-task
       params:
         - name: result
           value: "$(tasks.run-filter-task.results.result)"
-        - name: unreleased_rpms
-          value: "$(tasks.run-filter-task.results.unreleased_rpms)"
-        - name: in_advisory_rpms
-          value: "$(tasks.run-filter-task.results.in_advisory_rpms)"
+        - name: filter_results_artifact
+          value: "$(tasks.run-filter-task.results.filter_results_artifact)"
         - name: advisory_url
           value: "$(tasks.run-filter-task.results.advisory_url)"
       taskSpec:
         params:
           - name: result
             type: string
-          - name: unreleased_rpms
-            type: string
-          - name: in_advisory_rpms
+          - name: filter_results_artifact
             type: string
           - name: advisory_url
             type: string
@@ -58,8 +71,21 @@ spec:
                 exit 1
               fi
 
-              UNRELEASED=$(base64 -d <<< "$(params.unreleased_rpms)" | gunzip)
-              IN_ADVISORY=$(base64 -d <<< "$(params.in_advisory_rpms)" | gunzip)
+              ARTIFACT="$(params.filter_results_artifact)"
+              if [[ -z "$ARTIFACT" ]]; then
+                echo "Expected filter_results_artifact to be set"
+                exit 1
+              fi
+              echo "Filter results artifact: $ARTIFACT"
+
+              # Pull and extract the OCI artifact
+              oci_ref="${ARTIFACT#oci:}"
+              RESULTS_DIR=$(mktemp -d)
+              oras pull --insecure "${oci_ref}" -o "$RESULTS_DIR"
+              tar -xzf "$RESULTS_DIR/filter-results.tar.gz" -C "$RESULTS_DIR"
+
+              UNRELEASED=$(cat "$RESULTS_DIR/unreleased_rpms.json")
+              IN_ADVISORY=$(cat "$RESULTS_DIR/in_advisory_rpms.json")
 
               echo "Unreleased RPMs: $UNRELEASED"
               echo "In-advisory RPMs: $IN_ADVISORY"
@@ -84,4 +110,5 @@ spec:
               fi
               echo "Advisory URL: $ADVISORY_URL"
 
+              rm -rf "$RESULTS_DIR"
               echo "Validation successful!"

--- a/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-no-advisories.yaml
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-no-advisories.yaml
@@ -7,6 +7,21 @@ spec:
   description: |
     Test the filter-already-released-advisory-rpms-task when no advisories exist.
     All RPMs should be returned as unreleased.
+  params:
+    - name: ociStorage
+      description: The OCI repository where artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      type: string
+      default: "1d"
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
   tasks:
     - name: run-filter-task
       taskRef:
@@ -21,23 +36,21 @@ spec:
           value: "filter-advisory-rpms-secret"
         - name: internalRequestPipelineRunName
           value: "$(context.pipelineRun.name)"
+        - name: ociStorage
+          value: $(params.ociStorage)
     - name: validate-result
       runAfter:
         - run-filter-task
       params:
         - name: result
           value: "$(tasks.run-filter-task.results.result)"
-        - name: unreleased_rpms
-          value: "$(tasks.run-filter-task.results.unreleased_rpms)"
-        - name: in_advisory_rpms
-          value: "$(tasks.run-filter-task.results.in_advisory_rpms)"
+        - name: filter_results_artifact
+          value: "$(tasks.run-filter-task.results.filter_results_artifact)"
       taskSpec:
         params:
           - name: result
             type: string
-          - name: unreleased_rpms
-            type: string
-          - name: in_advisory_rpms
+          - name: filter_results_artifact
             type: string
         steps:
           - name: validate
@@ -53,8 +66,21 @@ spec:
                 exit 1
               fi
 
-              UNRELEASED=$(base64 -d <<< "$(params.unreleased_rpms)" | gunzip)
-              IN_ADVISORY=$(base64 -d <<< "$(params.in_advisory_rpms)" | gunzip)
+              ARTIFACT="$(params.filter_results_artifact)"
+              if [[ -z "$ARTIFACT" ]]; then
+                echo "Expected filter_results_artifact to be set"
+                exit 1
+              fi
+              echo "Filter results artifact: $ARTIFACT"
+
+              # Pull and extract the OCI artifact
+              oci_ref="${ARTIFACT#oci:}"
+              RESULTS_DIR=$(mktemp -d)
+              oras pull --insecure "${oci_ref}" -o "$RESULTS_DIR"
+              tar -xzf "$RESULTS_DIR/filter-results.tar.gz" -C "$RESULTS_DIR"
+
+              UNRELEASED=$(cat "$RESULTS_DIR/unreleased_rpms.json")
+              IN_ADVISORY=$(cat "$RESULTS_DIR/in_advisory_rpms.json")
 
               echo "Unreleased RPMs: $UNRELEASED"
               echo "In-advisory RPMs: $IN_ADVISORY"
@@ -72,4 +98,5 @@ spec:
                 exit 1
               fi
 
+              rm -rf "$RESULTS_DIR"
               echo "Validation successful!"

--- a/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-partial-release.yaml
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-partial-release.yaml
@@ -7,6 +7,21 @@ spec:
   description: |
     Test the filter-already-released-advisory-rpms-task with partial release.
     One RPM is in an advisory (released-rpm), one is not (new-rpm).
+  params:
+    - name: ociStorage
+      description: The OCI repository where artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      type: string
+      default: "1d"
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
   tasks:
     - name: run-filter-task
       taskRef:
@@ -22,23 +37,21 @@ spec:
           value: "filter-advisory-rpms-secret"
         - name: internalRequestPipelineRunName
           value: "$(context.pipelineRun.name)"
+        - name: ociStorage
+          value: $(params.ociStorage)
     - name: validate-result
       runAfter:
         - run-filter-task
       params:
         - name: result
           value: "$(tasks.run-filter-task.results.result)"
-        - name: unreleased_rpms
-          value: "$(tasks.run-filter-task.results.unreleased_rpms)"
-        - name: in_advisory_rpms
-          value: "$(tasks.run-filter-task.results.in_advisory_rpms)"
+        - name: filter_results_artifact
+          value: "$(tasks.run-filter-task.results.filter_results_artifact)"
       taskSpec:
         params:
           - name: result
             type: string
-          - name: unreleased_rpms
-            type: string
-          - name: in_advisory_rpms
+          - name: filter_results_artifact
             type: string
         steps:
           - name: validate
@@ -54,8 +67,21 @@ spec:
                 exit 1
               fi
 
-              UNRELEASED=$(base64 -d <<< "$(params.unreleased_rpms)" | gunzip)
-              IN_ADVISORY=$(base64 -d <<< "$(params.in_advisory_rpms)" | gunzip)
+              ARTIFACT="$(params.filter_results_artifact)"
+              if [[ -z "$ARTIFACT" ]]; then
+                echo "Expected filter_results_artifact to be set"
+                exit 1
+              fi
+              echo "Filter results artifact: $ARTIFACT"
+
+              # Pull and extract the OCI artifact
+              oci_ref="${ARTIFACT#oci:}"
+              RESULTS_DIR=$(mktemp -d)
+              oras pull --insecure "${oci_ref}" -o "$RESULTS_DIR"
+              tar -xzf "$RESULTS_DIR/filter-results.tar.gz" -C "$RESULTS_DIR"
+
+              UNRELEASED=$(cat "$RESULTS_DIR/unreleased_rpms.json")
+              IN_ADVISORY=$(cat "$RESULTS_DIR/in_advisory_rpms.json")
 
               echo "Unreleased RPMs: $UNRELEASED"
               echo "In-advisory RPMs: $IN_ADVISORY"
@@ -87,4 +113,5 @@ spec:
                 exit 1
               fi
 
+              rm -rf "$RESULTS_DIR"
               echo "Validation successful!"

--- a/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
@@ -311,31 +311,47 @@ spec:
         # Returns empty string if nothing is published
         get_repo_published_version_href() {
           local repo_name="$1"
-          local dist_response publication_href publication_json repo_version_href
+          local dist_response publication_href publication_json
+          local repo_version_href repo_href repo_json
 
           # Get distribution for this repo
           dist_response=$(curl_auth -s \
             "${PULP_BASE_URL}/api/pulp/${PULP_DOMAIN}/api/v3/distributions/rpm/rpm/?name=${repo_name}")
 
           # Check if distribution has a repository_version (direct link)
-          repo_version_href=$(jq -r '.results[0].repository_version // empty' <<< "${dist_response}")
+          repo_version_href=$(jq -r \
+            '.results[0].repository_version // empty' <<< "${dist_response}")
           if [[ -n "${repo_version_href}" && "${repo_version_href}" != "null" ]]; then
             echo "${repo_version_href}"
             return 0
           fi
 
           # Otherwise check if it has a publication
-          publication_href=$(jq -r '.results[0].publication // empty' <<< "${dist_response}")
-          if [[ -z "${publication_href}" || "${publication_href}" == "null" ]]; then
-            # No publication → nothing is published
-            echo ""
+          publication_href=$(jq -r \
+            '.results[0].publication // empty' <<< "${dist_response}")
+          if [[ -n "${publication_href}" && "${publication_href}" != "null" ]]; then
+            publication_json=$(curl_auth -s "${PULP_BASE_URL}${publication_href}")
+            repo_version_href=$(jq -r \
+              '.repository_version // empty' <<< "${publication_json}")
+            echo "${repo_version_href}"
             return 0
           fi
 
-          # Get the repository version from the publication
-          publication_json=$(curl_auth -s "${PULP_BASE_URL}${publication_href}")
-          repo_version_href=$(jq -r '.repository_version // empty' <<< "${publication_json}")
-          echo "${repo_version_href}"
+          # Fallback: check repository's latest version directly
+          repo_href=$(jq -r \
+            '.results[0].repository // empty' <<< "${dist_response}")
+          if [[ -n "${repo_href}" && "${repo_href}" != "null" ]]; then
+            repo_json=$(curl_auth -s \
+              "${PULP_BASE_URL}${repo_href}")
+            repo_version_href=$(jq -r \
+              '.latest_version_href // empty' <<< "${repo_json}")
+            if [[ -n "${repo_version_href}" && "${repo_version_href}" != "null" ]]; then
+              echo "${repo_version_href}"
+              return 0
+            fi
+          fi
+
+          echo ""
         }
 
         # Check Pulp for RPM digest in PUBLISHED content only.
@@ -394,11 +410,15 @@ spec:
 
         RPM_REPOS_JSON="$(jq -c '.mapping["rpm-repositories"] // []' "${DATA_FILE}")"
 
+        declare -A ARCH_REPO_INFO_CACHE
+        while IFS= read -r _repo_line; do
+          _arch="$(jq -r '.arch' <<< "$_repo_line")"
+          [[ -z "${ARCH_REPO_INFO_CACHE[$_arch]+x}" ]] && \
+            ARCH_REPO_INFO_CACHE["$_arch"]="$(jq -c '{repository_id, repository_name, distro}' <<< "$_repo_line")"
+        done < <(jq -c '.[]' <<< "$RPM_REPOS_JSON")
+
         get_repo_info_for_arch() {
-          local arch="$1"
-          jq -c --arg arch "${arch}" \
-            '.[] | select(.arch == $arch) | {repository_id, repository_name, distro}' \
-            <<< "${RPM_REPOS_JSON}" | head -1
+          echo "${ARCH_REPO_INFO_CACHE[$1]:-}"
         }
 
         should_exclude_file() {
@@ -447,9 +467,8 @@ spec:
         echo "Extracting RPMs and building purl data..."
         snapshot_json="$(jq '.' "${SNAPSHOT_FILE}")"
         TRANSFORMED_ENTRIES_FILE="$(mktemp)"
-        echo "[]" > "$TRANSFORMED_ENTRIES_FILE"
-        COMPONENT_RPMS_MAP_FILE="$(mktemp)"
-        echo "{}" > "$COMPONENT_RPMS_MAP_FILE"
+        : > "$TRANSFORMED_ENTRIES_FILE"
+        COMPONENT_RPMS_MAP_DIR="$(mktemp -d)"
 
         DEFAULT_ARCH_LIST=()
         IFS=',' read -ra _raw_default <<< "$(params.DEFAULT_ARCHITECTURES)"
@@ -458,18 +477,21 @@ spec:
           [[ -n "$x" ]] && DEFAULT_ARCH_LIST+=("$x")
         done
 
-        NOARCH_TARGET_REPOS_JSON="[]"
+        NOARCH_TARGET_REPOS=()
         for default_arch in "${DEFAULT_ARCH_LIST[@]}"; do
           repo_info="$(get_repo_info_for_arch "${default_arch}")"
-          [[ -n "${repo_info}" ]] && NOARCH_TARGET_REPOS_JSON="$(jq --argjson info "${repo_info}" \
-            '. + [$info]' <<< "${NOARCH_TARGET_REPOS_JSON}")"
+          [[ -n "${repo_info}" ]] && NOARCH_TARGET_REPOS+=("${repo_info}")
         done
 
+        json_escape() {
+          local s="$1"
+          s="${s//\\/\\\\}"
+          s="${s//\"/\\\"}"
+          echo -n "$s"
+        }
+
         while IFS= read -r component; do
-          comp_file="$(mktemp)"
-          echo "$component" > "$comp_file"
-          image="$(jq -r '.containerImage' "$comp_file")"
-          name="$(jq -r '.name' "$comp_file")"
+          IFS='|' read -r image name <<< "$(jq -r '[.containerImage, .name] | join("|")' <<< "$component")"
           echo "Processing component '${name}' (${image})" >&2
 
           workdir="$(mktemp -d)"
@@ -490,16 +512,15 @@ spec:
           )
 
           if [[ ${#files[@]} -eq 0 ]]; then
-            rm -rf "${workdir}" "$comp_file"
+            rm -rf "${workdir}"
             continue
           fi
 
           mapfile -t ARCHES < <(extract_arches_from_files files)
           [[ ${#ARCHES[@]} -eq 0 ]] && ARCHES=("${DEFAULT_ARCH_LIST[@]}")
 
-          # Use file for COMPONENT_RPMS to avoid ARG_MAX limit
           COMPONENT_RPMS_FILE="$(mktemp)"
-          echo "[]" > "$COMPONENT_RPMS_FILE"
+          : > "$COMPONENT_RPMS_FILE"
 
           for f in "${files[@]}"; do
             file_abs="${workdir}/files/${f}"
@@ -509,75 +530,74 @@ spec:
             IFS='|' read -r rpmname epoch version release arch <<< "${q}"
             [[ -z "${epoch}" || "${epoch}" == "(none)" ]] && epoch="0"
 
+            target_repos=()
             if [[ "${f}" == *.src.rpm ]]; then
               arch="src"
-              # Source RPMs use arch="src" in the mapping
               repo_info="$(get_repo_info_for_arch "src")"
               if [[ -n "${repo_info}" ]]; then
-                target_repos_json="[${repo_info}]"
+                target_repos=("${repo_info}")
               else
                 echo "Warning: No repository mapping for source arch, skipping ${f}" >&2
                 continue
               fi
             elif [[ "${f}" == *.noarch.rpm ]]; then
-              [[ "$(jq 'length' <<< "${NOARCH_TARGET_REPOS_JSON}")" -eq 0 ]] && continue
-              target_repos_json="${NOARCH_TARGET_REPOS_JSON}"
+              [[ ${#NOARCH_TARGET_REPOS[@]} -eq 0 ]] && continue
+              target_repos=("${NOARCH_TARGET_REPOS[@]}")
             else
               repo_info="$(get_repo_info_for_arch "${arch}")"
               [[ -z "${repo_info}" ]] && continue
-              target_repos_json="[${repo_info}]"
+              target_repos=("${repo_info}")
             fi
 
-            while IFS= read -r repo_obj; do
-              repo_name="$(jq -r '.repository_name' <<< "${repo_obj}")"
-              repo_id="$(jq -r '.repository_id' <<< "${repo_obj}")"
-              distro="$(jq -r '.distro' <<< "${repo_obj}")"
+            for repo_obj in "${target_repos[@]}"; do
+              IFS='|' read -r repo_name repo_id distro <<< \
+                "$(jq -r '[.repository_name, .repository_id, .distro] | join("|")' <<< "${repo_obj}")"
               purl="pkg:rpm/redhat/${rpmname}@${version}-${release}?arch=${arch}"
               [[ -n "${distro}" && "${distro}" != "null" ]] && purl="${purl}&distro=${distro}"
               [[ -n "${repo_id}" && "${repo_id}" != "null" ]] && purl="${purl}&repository_id=${repo_id}"
 
-              entry=$(jq -n \
-                --arg name "$name" --arg purl "$purl" --arg sha256 "$local_sha" \
-                --arg rpmname "$rpmname" --arg epoch "$epoch" --arg version "$version" \
-                --arg release "$release" --arg arch "$arch" \
-                --arg repository_name "$repo_name" --arg rpm "$f" \
-                --argjson targetRepo "$repo_obj" \
-                '{name: $name, purl: $purl, sha256: $sha256, rpmname: $rpmname,
-                  epoch: $epoch, version: $version, release: $release, arch: $arch,
-                  repository_name: $repository_name, rpm: $rpm, targetRepo: $targetRepo}')
-              # Append entry to file to avoid ARG_MAX limit
-              entry_tmp="$(mktemp)"
-              echo "$entry" > "$entry_tmp"
-              jq --slurpfile e "$entry_tmp" '. + $e' "$TRANSFORMED_ENTRIES_FILE" > "${TRANSFORMED_ENTRIES_FILE}.tmp"
-              mv "${TRANSFORMED_ENTRIES_FILE}.tmp" "$TRANSFORMED_ENTRIES_FILE"
-              rm -f "$entry_tmp"
+              _fmt='{"name":"%s","purl":"%s","sha256":"%s",'
+              _fmt+='"rpmname":"%s","epoch":"%s","version":"%s",'
+              _fmt+='"release":"%s","arch":"%s",'
+              _fmt+='"repository_name":"%s","rpm":"%s",'
+              _fmt+='"targetRepo":%s}\n'
+              # shellcheck disable=SC2059
+              printf "$_fmt" \
+                "$(json_escape "$name")" \
+                "$(json_escape "$purl")" "$local_sha" \
+                "$(json_escape "$rpmname")" "$epoch" \
+                "$(json_escape "$version")" \
+                "$(json_escape "$release")" "$arch" \
+                "$(json_escape "$repo_name")" \
+                "$(json_escape "$f")" "$repo_obj" \
+                >> "$TRANSFORMED_ENTRIES_FILE"
 
-              # Append to COMPONENT_RPMS_FILE using file operations
-              rpm_entry_tmp="$(mktemp)"
-              jq -n --arg rpm "$f" --arg sha "$local_sha" \
-                --arg rpmname "$rpmname" --arg epoch "$epoch" \
-                --arg version "$version" --arg release "$release" \
-                --arg arch "$arch" --argjson targetRepo "$repo_obj" \
-                '{rpm: $rpm, sha256: $sha, rpmname: $rpmname, epoch: $epoch,
-                 version: $version, release: $release, arch: $arch,
-                 targetRepos: [$targetRepo]}' > "$rpm_entry_tmp"
-              jq --slurpfile e "$rpm_entry_tmp" '. + $e' "$COMPONENT_RPMS_FILE" > "${COMPONENT_RPMS_FILE}.tmp"
-              mv "${COMPONENT_RPMS_FILE}.tmp" "$COMPONENT_RPMS_FILE"
-              rm -f "$rpm_entry_tmp"
-            done < <(jq -c '.[]' <<< "${target_repos_json}")
+              _rfmt='{"rpm":"%s","sha256":"%s",'
+              _rfmt+='"rpmname":"%s","epoch":"%s",'
+              _rfmt+='"version":"%s","release":"%s",'
+              _rfmt+='"arch":"%s","targetRepos":[%s]}\n'
+              # shellcheck disable=SC2059
+              printf "$_rfmt" \
+                "$(json_escape "$f")" "$local_sha" \
+                "$(json_escape "$rpmname")" "$epoch" \
+                "$(json_escape "$version")" \
+                "$(json_escape "$release")" \
+                "$arch" "$repo_obj" \
+                >> "$COMPONENT_RPMS_FILE"
+            done
           done
 
-          # Add component RPMs to map
-          jq --arg name "$name" --slurpfile rpms "$COMPONENT_RPMS_FILE" \
-            '. + {($name): $rpms[0]}' "$COMPONENT_RPMS_MAP_FILE" > "${COMPONENT_RPMS_MAP_FILE}.tmp"
-          mv "${COMPONENT_RPMS_MAP_FILE}.tmp" "$COMPONENT_RPMS_MAP_FILE"
+          if [[ -s "$COMPONENT_RPMS_FILE" ]]; then
+            jq -s '.' "$COMPONENT_RPMS_FILE" > "${COMPONENT_RPMS_MAP_DIR}/${name}.json"
+          fi
           rm -f "$COMPONENT_RPMS_FILE"
-          rm -rf "${workdir}" "$comp_file"
+          rm -rf "${workdir}"
         done < <(jq -c '.components[]' <<< "${snapshot_json}")
 
-        echo "Total transformed entries: $(jq 'length' "$TRANSFORMED_ENTRIES_FILE")"
+        TOTAL_ENTRIES=$(wc -l < "$TRANSFORMED_ENTRIES_FILE")
+        echo "Total transformed entries: $TOTAL_ENTRIES"
 
-        if [[ "$(jq 'length' "$TRANSFORMED_ENTRIES_FILE")" -eq 0 ]]; then
+        if [[ "$TOTAL_ENTRIES" -eq 0 ]]; then
           echo "No RPMs found in any component, skipping release"
           echo -n "true" > "$(results.skip_release.path)"
           echo -n "" > "$(results.latest_advisory_url.path)"
@@ -587,7 +607,7 @@ spec:
           exit 0
         fi
 
-        transformedSnapshot=$(gzip -c < "$TRANSFORMED_ENTRIES_FILE" | base64 -w 0)
+        transformedSnapshot=$(jq -s '.' "$TRANSFORMED_ENTRIES_FILE" | gzip -c | base64 -w 0)
 
         # === Phase 2: Create InternalRequest (no Pulp params) ===
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
@@ -656,18 +676,7 @@ spec:
           IN_ADVISORY_COUNT=$(jq 'length' "$IN_ADVISORY_FILE")
           echo "Validating Pulp digests for $IN_ADVISORY_COUNT in-advisory RPMs..."
 
-          while IFS= read -r rpm_entry; do
-            entry_file=$(mktemp)
-            echo "$rpm_entry" > "$entry_file"
-
-            rpmname=$(jq -r '.rpmname' "$entry_file")
-            epoch=$(jq -r '.epoch' "$entry_file")
-            version=$(jq -r '.version' "$entry_file")
-            release=$(jq -r '.release' "$entry_file")
-            arch=$(jq -r '.arch' "$entry_file")
-            sha256=$(jq -r '.sha256' "$entry_file")
-            repo_name=$(jq -r '.repository_name' "$entry_file")
-
+          while IFS='|' read -r rpmname epoch version release arch sha256 repo_name; do
             echo "Checking Pulp digest for ${rpmname}-${version}-${release}.${arch}..."
 
             set +e
@@ -688,20 +697,19 @@ spec:
                 echo "RPM: ${rpmname}-${version}-${release}.${arch}"
                 echo "Snapshot sha256: ${sha256}"
                 echo "Action required: Bump version or release number"
-                rm -f "$entry_file"
                 rm -rf "$FILTER_RESULTS_DIR"
                 exit 1
                 ;;
               *)
                 echo "Error: Failed to check Pulp digest (status=$pulp_status)"
-                rm -f "$entry_file"
                 rm -rf "$FILTER_RESULTS_DIR"
                 exit 1
                 ;;
             esac
-
-            rm -f "$entry_file"
-          done < <(jq -c '.[]' "$IN_ADVISORY_FILE")
+          done < <(jq -r \
+            '.[] | [.rpmname, .epoch, .version, .release,
+                    .arch, .sha256, .repository_name]
+                   | join("|")' "$IN_ADVISORY_FILE")
         fi
 
         # === Phase 5: Process unreleased RPMs and filter snapshot ===
@@ -728,7 +736,8 @@ spec:
         fi
 
         # Build filtered snapshot with rpmsToPublish for unreleased components
-        FILTERED_COMPONENTS="[]"
+        FILTERED_COMPS_FILE="$(mktemp)"
+        : > "$FILTERED_COMPS_FILE"
         while IFS= read -r comp_name; do
           [[ -z "$comp_name" ]] && continue
 
@@ -736,27 +745,16 @@ spec:
             '.components[] | select(.name == $name)' <<< "$snapshot_json")
           [[ -z "$original_component" ]] && continue
 
-          comp_rpms=$(jq --arg name "$comp_name" '.[$name] // []' "$COMPONENT_RPMS_MAP_FILE")
-          [[ "$(jq 'length' <<< "$comp_rpms")" -eq 0 ]] && continue
+          comp_rpms_file="${COMPONENT_RPMS_MAP_DIR}/${comp_name}.json"
+          [[ ! -s "$comp_rpms_file" ]] && continue
 
-          rpms_file="$(mktemp)"
-          echo "$comp_rpms" > "$rpms_file"
-          updated_component=$(echo "$original_component" | \
-            jq --slurpfile rpms "$rpms_file" '. + {rpmsToPublish: $rpms[0]}')
-          rm -f "$rpms_file"
-
-          comp_file="$(mktemp)"
-          echo "$updated_component" > "$comp_file"
-          FILTERED_COMPONENTS=$(jq --slurpfile comp "$comp_file" '. + $comp' <<< "$FILTERED_COMPONENTS")
-          rm -f "$comp_file"
+          echo "$original_component" | \
+            jq --slurpfile rpms "$comp_rpms_file" '. + {rpmsToPublish: $rpms[0]}' \
+            >> "$FILTERED_COMPS_FILE"
         done < <(jq -r '.[]' <<< "$UNRELEASED_COMPONENTS")
 
-        # Use file instead of --argjson to avoid "Argument list too long" error
-        COMPS_FILE="$(mktemp)"
-        echo "$FILTERED_COMPONENTS" > "$COMPS_FILE"
-        jq --slurpfile comps "$COMPS_FILE" \
-          '.components = $comps[0]' "${SNAPSHOT_FILE}" > "${SNAPSHOT_FILE}.tmp"
-        rm -f "$COMPS_FILE"
+        jq --slurpfile comps "$FILTERED_COMPS_FILE" \
+          '.components = $comps' "${SNAPSHOT_FILE}" > "${SNAPSHOT_FILE}.tmp"
         mv "${SNAPSHOT_FILE}.tmp" "${SNAPSHOT_FILE}"
 
         echo "Filtered snapshot components: $(jq '.components | length' "${SNAPSHOT_FILE}")"
@@ -764,7 +762,7 @@ spec:
         echo -n "" > "$(results.latest_advisory_url.path)"
         echo -n "" > "$(results.latest_advisory_internal_url.path)"
 
-        rm -rf "$UNRELEASED_FILE" "$COMPONENT_RPMS_MAP_FILE" "$TRANSFORMED_ENTRIES_FILE" "$FILTER_RESULTS_DIR"
+        rm -rf "$FILTERED_COMPS_FILE" "$COMPONENT_RPMS_MAP_DIR" "$TRANSFORMED_ENTRIES_FILE" "$FILTER_RESULTS_DIR"
     - name: create-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/mocks.sh
@@ -11,10 +11,10 @@ function select-oci-auth() {
 function oras() {
   echo "Mock oras called with: $*"
   echo $* >> $(params.dataDir)/mock_oras.txt
-  local args="$*"
 
   if [[ "$*" == "pull --registry-config"* ]]; then
     output_file_dir=""
+    local oci_ref=""
     echo "none" > "${CONTENT_EXISTS_MODE_FILE}"
     while [[ $# -gt 0 ]]; do
       case "$1" in
@@ -22,20 +22,45 @@ function oras() {
           output_file_dir="$2"
           shift 2
           ;;
+        --registry-config)
+          shift 2
+          ;;
+        pull)
+          shift
+          ;;
         *)
+          oci_ref="$1"
           shift
           ;;
       esac
     done
 
     mkdir -p "${output_file_dir}"
-    touch "${output_file_dir}/hello-2.12.1-6.fc44.aarch64.rpm"
-    touch "${output_file_dir}/hello-2.12.1-6.fc44.ppc64le.rpm"
-    touch "${output_file_dir}/hello-2.12.1-6.fc44.s390x.rpm"
-    touch "${output_file_dir}/hello-2.12.1-6.fc44.src.rpm"
-    touch "${output_file_dir}/hello-2.12.1-6.fc44.x86_64.rpm"
-    touch "${output_file_dir}/hello-docs-2.12.1-6.fc44.noarch.rpm"
-    mkdir -p "${output_file_dir}/logs"
+
+    if [[ "$oci_ref" == *"filter-results"* ]]; then
+      # Filter results artifact pull - create the tarball
+      local tmpdir
+      tmpdir=$(mktemp -d)
+      cat /tmp/mock_unreleased_rpms.json > "$tmpdir/unreleased_rpms.json"
+      cat /tmp/mock_in_advisory_rpms.json > "$tmpdir/in_advisory_rpms.json"
+      tar -czf "${output_file_dir}/filter-results.tar.gz" \
+        -C "$tmpdir" unreleased_rpms.json in_advisory_rpms.json
+      rm -rf "$tmpdir"
+    else
+      # RPM artifact pull - create mock RPM files
+      touch "${output_file_dir}/hello-2.12.1-6.fc44.aarch64.rpm"
+      touch "${output_file_dir}/hello-2.12.1-6.fc44.ppc64le.rpm"
+      touch "${output_file_dir}/hello-2.12.1-6.fc44.s390x.rpm"
+      touch "${output_file_dir}/hello-2.12.1-6.fc44.src.rpm"
+      touch "${output_file_dir}/hello-2.12.1-6.fc44.x86_64.rpm"
+      touch "${output_file_dir}/hello-docs-2.12.1-6.fc44.noarch.rpm"
+      mkdir -p "${output_file_dir}/logs"
+    fi
+    return 0
+  fi
+
+  if [[ "$*" == "push"* ]] || [[ "$*" == "manifest"* ]]; then
+    echo "sha256:mockdigest123"
     return 0
   fi
 }
@@ -99,13 +124,15 @@ function internal-request() {
 }
 
 function kubectl() {
-  UNRELEASED_RPMS=$(echo -n '[{"name":"test-component","purl":"pkg:rpm/redhat/hello@2.12.1-6.fc44?arch=x86_64","sha256":"abc123","rpmname":"hello","epoch":"0","version":"2.12.1","release":"6.fc44","arch":"x86_64","repository_name":"x86_64"}]' | gzip -c | base64 -w 0)
-  IN_ADVISORY_RPMS=$(echo -n '[]' | gzip -c | base64 -w 0)
+  # Write mock filter result files for the oras pull mock to serve
+  cat > /tmp/mock_unreleased_rpms.json << 'MOCKEOF'
+[{"name":"test-component","purl":"pkg:rpm/redhat/hello@2.12.1-6.fc44?arch=x86_64","sha256":"abc123","rpmname":"hello","epoch":"0","version":"2.12.1","release":"6.fc44","arch":"x86_64","repository_name":"x86_64"}]
+MOCKEOF
+  echo '[]' > /tmp/mock_in_advisory_rpms.json
 
   MOCK_RESULTS='{
     "result": "Success",
-    "unreleased_rpms": "'"$UNRELEASED_RPMS"'",
-    "in_advisory_rpms": "'"$IN_ADVISORY_RPMS"'",
+    "filter_results_artifact": "oci:quay.io/mock/filter-results@sha256:mockdigest123",
     "internalRequestPipelineRunName": "test-pipeline-run",
     "internalRequestTaskRunName": "test-task-run",
     "advisory_url": "",


### PR DESCRIPTION
## Describe your changes

Replace O(n²) JSON array building with JSONL append + single jq -s pass, cache arch-to-repo lookups in associative arrays, combine multiple jq field extractions into single calls, and use printf-based JSON construction instead of jq -n per entry. In the internal task, replace per-RPM bash loop with a single jq reduce pass and push filter results via OCI artifact instead of inline task results.

Update tests for both managed and internal tasks to validate the new OCI artifact flow and fix mock functions for the updated yq/oras calling conventions.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
